### PR TITLE
Fix rethrowing endpoint exceptions

### DIFF
--- a/src/PaySimpleSdk/Helpers/WebServiceRequest.cs
+++ b/src/PaySimpleSdk/Helpers/WebServiceRequest.cs
@@ -171,15 +171,15 @@ namespace PaySimpleSdk.Helpers
                     return result;
 
                 var content = await result.Content.ReadAsStringAsync();
-	            try
-	            {
-					var errors = serialization.Deserialize<ErrorResult>(content);
-					throw new PaySimpleEndpointException(errors, result.StatusCode);
-	            }
-	            catch (Exception e)
-	            {
-		            throw new PaySimpleEndpointException($"Error deserializing response: {content}", e);
-	            }
+                try
+                {
+                    var errors = serialization.Deserialize<ErrorResult>(content);
+                    throw new PaySimpleEndpointException(errors, result.StatusCode);
+                }
+                catch (Exception e) when (!(e is PaySimpleEndpointException))
+                {
+                    throw new PaySimpleEndpointException($"Error deserializing response: {content}", e);
+                }
             }
         }
     }


### PR DESCRIPTION
Any time PaySimple responded with a 400 Bad Request it was being wrapped in a PaySimpleEndpointException. However because of the try-catch block, it would always re-wrap it in another exception and lose the helpful ErrorResult information. I've added a catch-when to avoid this and properly preserve the original error info.